### PR TITLE
Wasp freezes on the main.py screen

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -587,6 +587,15 @@ Most problems with normal mode operation occur either because ``main.py`` is
 missing, out-of-date or corrupt. These issues most commonly result in an
 entirely black screen when running the watch is running in normal mode.
 
+Wasp freezes on the ``main.py`` screen
+
+The likely cause is that there is not enough room or memory on your device to
+freeze your applications into the wasp-os binary. To solve this, reduce the
+number of applications you are loading and reinstall. If you are developing
+your own application, it is best that you load the minimal set of applications
+to have the maximum possible amount of available RAM and minimum fragmentation.
+For example, only autoloading the software app will get you the maximum amount of RAM.
+
 .. note::
 
    If the system reports FAILED at boot, in either safe mode or normal


### PR DESCRIPTION
Most new users of WASP-OS do not know the limitations and may attempt to autoload a number of applications that exceed the capacity to freeze into the WASP-OS binary. This results in the watch freezing on the main.py screen. So the user will have to reduce the number of applications chosen and re-install.